### PR TITLE
Options for language model and speaker diarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const sm = new Speechmatics(userId, apiKey, options);
 
 `userId` and `apiKey` are required as the first two parameters for Speechmatics client instantiation. `options` are...optional. Defaults detailed below.
 
-#### Options
+### Options
 
 - `baseUrl`: string - defaults to 'https://api.speechmatics.com'
 - `apiVersion`: number - defaults to 1.0;
@@ -49,7 +49,7 @@ sm.getStatus(opts, callback);
 /* Statics */
 Speechmatics.parseAlignment(text);
 ```
-##### Gets
+### Gets
 
 If the response object has only a single key, the callback object is pared to that value. This provides a more simplified than the actual Speechmatics API. Specifically this applies, `getUser`, `getPayments`, `getJobs`, and `getJob`
 
@@ -77,7 +77,7 @@ Whereas, this module will simply return the value of the `user` key:
 }
 ```
 
-##### Create Job
+### Create Job
 
 `sm.createJob` has a built-in nicety. Setting `opts.audioFilename` or `opts.textFilename` (for alignment) will read those files from the supplied paths as a [ReadStream](https://nodejs.org/api/fs.html#fs_class_fs_readstream), which is then passed through to the request as the correct `formData` fields.
 
@@ -100,7 +100,7 @@ sm.createJob({audioStream: existingReadStream}, callback);
 
 *note: "auth_token" request parameter is automatically set based on apiKey*
 
-###### Languages
+### Languages
 
 - `opts.model` to specify language to use for transcription eg `en-US`. [See here for a list of supported languages](https://github.com/pietrop/Create-html-elements-for-speechmatics-languages/blob/master/languages.json).
 - `opts.diarisation` if you would like to know speakers for the transcription. Takes in boolean `true` or `false`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Whereas, this module will simply return the value of the `user` key:
 
 `sm.createJob` has a built-in nicety. Setting `opts.audioFilename` or `opts.textFilename` (for alignment) will read those files from the supplied paths as a [ReadStream](https://nodejs.org/api/fs.html#fs_class_fs_readstream), which is then passed through to the request as the correct `formData` fields.
 
+
+`opts.model` to specify language to use for transcription eg `en-US`. See speechmatics documentation for more on this.
+
+
 You can also use the `opts.audioStream` and `opts.textStream` parameters to pass in readable streams. This is useful when uploading from a remote source, for example:
 ```js
 var request = https.get("https://example.com/catVideo.webm")

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Whereas, this module will simply return the value of the `user` key:
 `sm.createJob` has a built-in nicety. Setting `opts.audioFilename` or `opts.textFilename` (for alignment) will read those files from the supplied paths as a [ReadStream](https://nodejs.org/api/fs.html#fs_class_fs_readstream), which is then passed through to the request as the correct `formData` fields.
 
 
-`opts.model` to specify language to use for transcription eg `en-US`. See speechmatics documentation for more on this.
 
 
 You can also use the `opts.audioStream` and `opts.textStream` parameters to pass in readable streams. This is useful when uploading from a remote source, for example:
@@ -100,3 +99,20 @@ sm.createJob({audioStream: existingReadStream}, callback);
 ```
 
 *note: "auth_token" request parameter is automatically set based on apiKey*
+
+###### Languages
+
+- `opts.model` to specify language to use for transcription eg `en-US`. [See here for a list of supported languages](https://github.com/pietrop/Create-html-elements-for-speechmatics-languages/blob/master/languages.json).
+- `opts.diarisation` if you would like to know speakers for the transcription. Takes in boolean `true` or `false`.
+
+
+```js
+var existingReadStream = fs.createReadStream("./zero.wav");
+sm.createJob({
+    audioStream: existingReadStream.
+    model: 'en',
+    diarisation: true
+  }, callback);
+```
+
+

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ sm.createJob({audioStream: existingReadStream}, callback);
 ```js
 var existingReadStream = fs.createReadStream("./zero.wav");
 sm.createJob({
-    audioStream: existingReadStream.
+    audioStream: existingReadStream,
     model: 'en',
     diarisation: true
   }, callback);

--- a/index.js
+++ b/index.js
@@ -69,8 +69,10 @@ class Client {
 
   post(path, opts, done) {
     opts = opts || {};
+    var model = opts.model;
+    delete opts.model;
     const fd = Object.assign({
-      model: opts.model, //eg 'en-US',
+      model: model, //eg 'en-US',
       diarisation: 'false'
     }, opts.formData);
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class Client {
   post(path, opts, done) {
     opts = opts || {};
     const fd = Object.assign({
-      model: 'en-US',
+      model: opts.model, //eg 'en-US',
       diarisation: 'false'
     }, opts.formData);
 

--- a/index.js
+++ b/index.js
@@ -69,8 +69,12 @@ class Client {
 
   post(path, opts, done) {
     opts = opts || {};
-    var model = opts.model;
-    //default 
+    //default for language model is english global
+    var model = 'en';
+     if(opts.model){
+      model = opts.model;
+     }
+    //default for speaker diarization is off
     var diarisation = 'false';
     if(opts.diarisation){
         if(opts.diarisation === true){
@@ -78,10 +82,10 @@ class Client {
       }
     }
     const fd = Object.assign({
-      model: model, //eg 'en-US',
+      model: model, //eg: 'en-US',
       diarisation: diarisation,
     }, opts.formData);
-
+    //clean up model and diarization 
     delete opts.model;
     delete opts.diarisation;
 

--- a/index.js
+++ b/index.js
@@ -70,11 +70,20 @@ class Client {
   post(path, opts, done) {
     opts = opts || {};
     var model = opts.model;
-    delete opts.model;
+    //default 
+    var diarisation = 'false';
+    if(opts.diarisation){
+        if(opts.diarisation === true){
+          diarisation = 'true';
+      }
+    }
     const fd = Object.assign({
       model: model, //eg 'en-US',
-      diarisation: 'false'
+      diarisation: diarisation,
     }, opts.formData);
+
+    delete opts.model;
+    delete opts.diarisation;
 
     if (this.callbackUrl) {
       fd.notification = 'callback';


### PR DESCRIPTION
As raised in this https://github.com/BessemerAlliance/speechmatics/issues/4 both model and speaker diarization are hardcoded, I have a use case for which I need to be able to translate in language other the US english, so added language model as an option and while I was at it I also added speaker diarization as optional.

However I also left `en` (Global English) as default for language model, and speaker diarization default to` false` if those options are not passed, so that this change can be backward compatible if this module is used elsewhere. 

Let me know if this works you. 